### PR TITLE
Allow developers to subclass PhoneFormattedTextField

### DIFF
--- a/PhoneNumberFormatter/Sources/PhoneFormattedTextField.swift
+++ b/PhoneNumberFormatter/Sources/PhoneFormattedTextField.swift
@@ -11,7 +11,7 @@ import UIKit
 /**
  UITextField subclass to handle phone numbers formats
 */
-final public class PhoneFormattedTextField: UITextField {
+public class PhoneFormattedTextField: UITextField {
 
     private let formatProxy: FormattedTextFieldDelegate
     private let formatter: PhoneFormatter


### PR DESCRIPTION
Thank you for taking my last pull request!

Enabling subclassing will allow developers to customize behavior that is best modified in a subclass (as opposed to an extension, which is possible but clunky as it affects all instances).

For example, I want to prevent the textfield from becoming first responder and disallow selection, but I still want to allow it to receive input via copy/paste (so setting userInteractionDisabled is too big of a stick).

This pull request is optional for me (we're going to use the version you published last night). So you can take some time to think the risks you would take by opening up the API to subclassing.

Thanks again,
-Bill