### PR TITLE
Explaining how to listen to changes on input

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
         textField.becomeFirstResponder()
 
         textField.textDidChangeBlock = { field in
-            if let text = field?.text {
+            if let text = field?.text, text != "" {
                 print(text)
             } else {
                 print("No text")

--- a/README.md
+++ b/README.md
@@ -64,9 +64,22 @@ let custom2 = PhoneFormat(phoneFormat: "(###) ###-###", regexp: "^2\\d*$")
 textField.config.add(format: custom2)
 ```
 
+### Listening to changes
+To be notified of changes on the textField input add a `textDidChangeBlock` closure
+```swift
+textField.textDidChangeBlock = { field in
+  if let text = field?.text, text != "" {
+      print(text)
+  } else {
+      print("No text")
+  }
+```
+
+Attempting to listen to changes through other means will likely fail (e.g., implementing `UITextFieldDelegate`'s `textField:shouldChangeCharactersIn:range:`).
+
 ## Requirements
 iOS 9+
-Swift 4 
+Swift 4
 
 ## License
 PhoneNumberFormatter is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
The usage of the `textDidChangeBlock` property was not explained on the `README`, and thus it was causing confusion as to how listening to changes should be implemented (see #3 and #9 ).

On this pull request I added a section to `README` called "Listening to Changes", explaining that the property should be used, and that other methods will not work.

I also added a condition to the `textDidChangeBlock` on the demo, so it prints when the input is indeed empty.

Hope you guys accept this, and if there is anything wrong I'd be glad to change.
Cheers.

resolves #3, resolves #9 